### PR TITLE
Remove 'z' axis from the projected image

### DIFF
--- a/src/napari_epitools/_tests/test_projection.py
+++ b/src/napari_epitools/_tests/test_projection.py
@@ -14,7 +14,7 @@ SMOOTHING_RADIUS = 0.2
 SURFACE_SMOOTHNESS_1 = 50
 SURFACE_SMOOTHNESS_2 = 50
 CUT_OFF_DISTANCE = 20
-PROJECTION_NDIM = 4
+PROJECTION_NDIM = 3
 
 
 @pytest.fixture
@@ -74,8 +74,7 @@ def test_calculate_projection(sample_data):
         )
         assert projection.ndim == PROJECTION_NDIM  # noqa: S101
         assert projection.shape == (  # noqa: S101
-            1,
-            1,
+            1,  # single frame in the timeseries
             sample_data.shape[1],
             sample_data.shape[2],
         )

--- a/src/napari_epitools/analysis/projection.py
+++ b/src/napari_epitools/analysis/projection.py
@@ -113,12 +113,13 @@ def calculate_projection(
         Stack projected onto a single plane.
     """
     if input_image.ndim == IMAGE_NDIM:
+        # assume we have a stack of images at a single point in time
         input_image = np.expand_dims(input_image, axis=0)
 
     t_size, z_size, y_size, x_size = input_image.shape
     smoothed_imstack = _smooth(input_image.astype(np.float64), smoothing_radius)
 
-    t_interp = np.zeros((t_size, 1, y_size, x_size))
+    t_interp = np.zeros((t_size, y_size, x_size))  # remove the z-axis when projecting
     for t in range(t_size):
         smoothed_t = smoothed_imstack[t]
         max_intensity = smoothed_t.max(axis=0)
@@ -135,7 +136,7 @@ def calculate_projection(
             max_indices_confthres, x_size, y_size, surface_smoothness_1
         )
 
-        # given the hight locations of the surface (z_interp) compute the difference
+        # given the height locations of the surface (z_interp) compute the difference
         # towards the 1st quartile location (max_indices_confthres), ignore the rest
         # (==0); the result reflects the distance (abs) between estimate and points.
         max_indices_diff = np.abs(z_interp - max_indices_confthres.astype("float64"))


### PR DESCRIPTION
Fixes #39 

- remove the `z` axis from the image when projecting a 3D stack to 2D. This is required if we later want to use the segmented image with `btrack`