### PR TITLE
Update default widget values

### DIFF
--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -29,7 +29,7 @@ SMOOTHING_RADIUS = {
     "min": 0.0,
     "max": 10.0,
     "step": 0.1,
-    "value": 0.2,
+    "value": 1,
 }
 
 SURFACE_SMOOTHNESS_1 = {
@@ -56,7 +56,7 @@ CUT_OFF_DISTANCE = {
     "min": 0,
     "max": 5,
     "step": 1,
-    "value": 2,
+    "value": 3,
 }
 
 SPOT_SIGMA = {
@@ -65,7 +65,7 @@ SPOT_SIGMA = {
     "min": 0,
     "max": 20,
     "step": 0.1,
-    "value": 3,
+    "value": 10,
 }
 
 OUTLINE_SIGMA = {
@@ -74,7 +74,7 @@ OUTLINE_SIGMA = {
     "min": 0,
     "max": 20,
     "step": 0.1,
-    "value": 0,
+    "value": 3,
 }
 
 THRESHOLD = {
@@ -83,7 +83,7 @@ THRESHOLD = {
     "min": 0,
     "max": 100,
     "step": 1,
-    "value": 20,
+    "value": 3,
 }
 PROJECTION_LAYER_NAME = "Projection"
 SEEDS_LAYER_NAME = "Seeds"


### PR DESCRIPTION
- update default values for the projection and segmentation widgets
- the new defaults provide pretty good results for our new 4d test data (although there are still a few areas that would need manual correction)

original projection with segmentation seeds shown on top:
![image](https://user-images.githubusercontent.com/29753790/227543864-8d6c42df-180a-464d-8bc9-69c12156cddd.png)

segmentation coloured by label:
![image](https://user-images.githubusercontent.com/29753790/227545309-60d25854-80db-40a0-b47e-c3f8fb1f66dd.png)
