### PR TITLE
Automatically select new Image layers

### DIFF
--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -178,7 +178,7 @@ def _init_segmentation_widget(widget):
 
     viewer = napari.current_viewer()
 
-    # Automatically select newly added Labels
+    # Automatically select a newly added Image layer
     viewer.layers.events.inserted.connect(
         lambda event: _select_inserted_image(event.value, widget.input_image),
     )
@@ -190,7 +190,9 @@ def _select_inserted_image(new_layer, widget):
     if not isinstance(new_layer, napari.layers.Image):
         return
 
-    widget.native.setCurrentIndex(len(widget) - 1)
+    widget.native.setCurrentIndex(
+        len(widget) - 1
+    )  # the new layer is always last in the list
 
 
 @magic_factory(

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -200,9 +200,8 @@ def _select_inserted_image(
     if not isinstance(new_layer, napari.layers.Image):
         return
 
-    widget.native.setCurrentIndex(
-        len(widget) - 1
-    )  # the new layer is always last in the list
+    # the new layer is always last in the list
+    widget.native.setCurrentIndex(len(widget) - 1)
 
 
 @magic_factory(

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -173,10 +173,31 @@ def projection_widget(
     return run()
 
 
+def _init_segmentation_widget(widget):
+    """Add callbacks for the widget"""
+
+    viewer = napari.current_viewer()
+
+    # Automatically select newly added Labels
+    viewer.layers.events.inserted.connect(
+        lambda event: _select_inserted_image(event.value, widget.input_image),
+    )
+
+
+def _select_inserted_image(new_layer, widget):
+    """Update the selected Image when a image layer is added"""
+
+    if not isinstance(new_layer, napari.layers.Image):
+        return
+
+    widget.native.setCurrentIndex(len(widget) - 1)
+
+
 @magic_factory(
     spot_sigma=SPOT_SIGMA,
     outline_sigma=OUTLINE_SIGMA,
     threshold=THRESHOLD,
+    widget_init=_init_segmentation_widget,
 )
 def segmentation_widget(
     input_image: napari.types.ImageData,

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import magicgui.widgets
+import napari.layers
 import napari.qt.threading
 import napari.types
 import numpy as np
@@ -173,18 +175,26 @@ def projection_widget(
     return run()
 
 
-def _init_segmentation_widget(widget):
-    """Add callbacks for the widget"""
+def _init_segmentation_widget(
+    container: magicgui.widgets._function_gui.FunctionGui,
+):
+    """Add callbacks for the widget that is used to select the input image"""
 
     viewer = napari.current_viewer()
 
     # Automatically select a newly added Image layer
     viewer.layers.events.inserted.connect(
-        lambda event: _select_inserted_image(event.value, widget.input_image),
+        lambda event: _select_inserted_image(
+            new_layer=event.value,
+            widget=container.input_image,
+        ),
     )
 
 
-def _select_inserted_image(new_layer, widget):
+def _select_inserted_image(
+    new_layer: napari.layers.Layer,
+    widget: magicgui.widgets.ComboBox,
+):
     """Update the selected Image when a image layer is added"""
 
     if not isinstance(new_layer, napari.layers.Image):


### PR DESCRIPTION
Fixes #15 

- the segmentation widget will now automatically select a new `Image` layer when it is added 

- if necessary, we could be more specific and select only Images added by the projection widget, but this would be a bit more complicated as we'd need to define and emit a signal from the projection widget

- I'm not sure if the way I've added the callback for selecting the image is the way it's usually done when using `magic_factory`, but it seems to work okay

