### PR TITLE
Add logging

### DIFF
--- a/src/napari_epitools/__init__.py
+++ b/src/napari_epitools/__init__.py
@@ -13,5 +13,5 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-logger.setLevel('INFO')
+logger.setLevel("DEBUG")
 logger.propagate = False

--- a/src/napari_epitools/__init__.py
+++ b/src/napari_epitools/__init__.py
@@ -13,5 +13,5 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-logger.setLevel("DEBUG")
+logger.setLevel("INFO")
 logger.propagate = False

--- a/src/napari_epitools/__init__.py
+++ b/src/napari_epitools/__init__.py
@@ -1,1 +1,17 @@
+import logging
+
 __version__ = "0.0.1"
+
+# get the logger instance
+logger = logging.getLogger(__name__)
+
+formatter = logging.Formatter(
+    "%(levelname)s [%(asctime)s] napari-epitools: %(message)s",
+    datefmt="%Y/%m/%d %I:%M:%S %p",
+)
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)
+
+logger.setLevel('INFO')
+logger.propagate = False

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -380,12 +380,12 @@ def _update_cell_statistics(
             layer.features = layer.metadata["cell_statistics"][frame]
         except KeyError:
             message = f"No cell statistics to load for layer {layer.name}"
-            logger.debug(message)
+            logger.log(level=1, msg=message)
         except IndexError:
             message = (
                 f"No cell statistics to load for layer {layer.name} at frame {frame}"
             )
-            logger.debug(message)
+            logger.log(level=9, msg=message)
 
 
 def run_cell_statistics(

--- a/src/napari_epitools/analysis/cell_statistics.py
+++ b/src/napari_epitools/analysis/cell_statistics.py
@@ -5,6 +5,7 @@ of labelled images using skimage.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,6 +17,8 @@ import networkx.exception
 import numpy as np
 import skimage.graph
 import skimage.measure
+
+logger = logging.getLogger(__name__)
 
 
 def calculate_cell_statistics(
@@ -72,11 +75,12 @@ def _create_graphs(
     graphs = [skimage.graph.RAG(frame_labels) for frame_labels in labels]
 
     # remove the background if it exists
-    for graph in graphs:
+    for index, graph in enumerate(graphs):
         try:
             graph.remove_node(0)
         except networkx.exception.NetworkXError:
-            pass
+            message = f"No background node to remove for graph at frame {index}"
+            logger.debug(message)
 
     return graphs
 

--- a/src/napari_epitools/analysis/cell_statistics.py
+++ b/src/napari_epitools/analysis/cell_statistics.py
@@ -78,9 +78,11 @@ def _create_graphs(
     for index, graph in enumerate(graphs):
         try:
             graph.remove_node(0)
+            message = f"Removing background node for graph at frame {index}"
+            logger.log(level=2, msg=message)
         except networkx.exception.NetworkXError:
             message = f"No background node to remove for graph at frame {index}"
-            logger.debug(message)
+            logger.log(level=2, msg=message)
 
     return graphs
 


### PR DESCRIPTION
Fixes #46 

- set up basic logging

- default level is set to "INFO", but all logging is done at the "DEBUG" level. So to see any of the messages we will need to set `logger.setLevel("DEBUG")` in `src/napari_epitools/__init__.py`. I've done this to hide these messages from users

- Any info, warning, or error messages that should be displayed to users don't use the logger - instead they're shown using `napari.utils.notifications`, which will show the message in a banner in the gui rather than printing to the console

- some of the log messages have an even lower level than "DEBUG", meaning they won't be printed when the log level is set to "DEBUG". This is because it's likely these messages will be printed a lot, e.g. when scrolling through frames, and they might make it difficult to see other log messages in the console. To print all messages to the console: `logger.setLevel(1)`

