### PR TITLE
Colour 'Labels' layers by cell statistics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
     "numpy",
     "scipy",
     "pandas",
+    "matplotlib",
     "napari",
+    "magicgui",
     "qtpy",
     "scikit-image>=0.20",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "napari-assistant",
-    "napari-pyclesperanto-assistant",
-    "napari-time-slicer>=0.4.8",
-    "napari-tools-menu",
     "numpy",
+    "scipy",
+    "pandas",
+    "napari",
     "qtpy",
     "scikit-image>=0.20",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ classifiers = [
 ]
 dependencies = [
     "napari-assistant",
-    "napari-skimage-regionprops",
+    "napari-pyclesperanto-assistant",
     "napari-time-slicer>=0.4.8",
     "napari-tools-menu",
     "numpy",
     "qtpy",
-    "scikit-image",
+    "scikit-image>=0.20",
 ]
 description = "EpiTools Plugin"
 dynamic = [

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -404,11 +404,11 @@ def _create_colour_labels_widgets() -> list[Widget]:
     statisitc_tooltip = "Select which statistic to use for colouring the 'Labels'"
     statistic = magicgui.widgets.create_widget(
         name="colourmap_statistic",
-        value="None",
+        value="id",
         label="statistic",
         widget_type="ComboBox",
         options={
-            "choices": ["None", "area", "perimeter", "orientation", "neighbours"],
+            "choices": ["id", "area", "perimeter", "orientation", "neighbours"],
             "tooltip": statisitc_tooltip,
         },
     )
@@ -588,7 +588,7 @@ def create_colourmaps(
 ) -> None:
     """Create a colourmap for a cell statistic each frame.
 
-    If the statistic is set to "None", then the colour mode is set to "auto", which will
+    If the statistic is set to "id", then the colour mode is set to "auto", which will
     colour regions based on their ids.
 
     If the statistics is set to any other value, a colourmap is created for that
@@ -603,7 +603,7 @@ def create_colourmaps(
         napari.utils.notifications.show_error(_msg)
         return
 
-    if colourmap_statistic == "None":
+    if colourmap_statistic == "id":
         labels.metadata.pop("metadata", None)
         labels.color_mode = "auto"
         return

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 import magicgui.widgets
+import matplotlib.pyplot as plt
 import napari.layers
 import napari.qt.threading
 import napari.types
@@ -282,9 +283,11 @@ def segmentation_widget(
 def cell_statistics_widget() -> magicgui.widgets.Container:
     """Create a widget for calculating cell statistics of labelled segmentations."""
 
-    widgets = _create_cell_statistics_widgets()
+    cell_statistics_widgets = _create_cell_statistics_widgets()
+    colour_labels_widgets = _create_colour_labels_widgets()
+
     cell_statistics_widget = magicgui.widgets.Container(
-        widgets=widgets,
+        widgets=[*cell_statistics_widgets, *colour_labels_widgets],
         scrollable=False,
     )
 
@@ -294,7 +297,8 @@ def cell_statistics_widget() -> magicgui.widgets.Container:
     # Update cell_statistics when scrolling through frames
     viewer.dims.events.current_step.connect(
         lambda event: _update_cell_statistics(
-            layers=viewer.layers, frame=event.value[0]
+            layers=viewer.layers,
+            frame=event.value[0],
         ),
     )
 
@@ -311,6 +315,17 @@ def cell_statistics_widget() -> magicgui.widgets.Container:
         lambda: export_cell_statistics(
             labels=cell_statistics_widget.input_labels.value,
         ),
+    )
+
+    # create colourmap for selected Labels
+    cell_statistics_widget.colourmap_create_button.changed.connect(
+        lambda: create_colourmaps(
+            labels=cell_statistics_widget.colourmap_input_labels.value,
+            colourmap_statistic=cell_statistics_widget.colourmap_statistic.current_choice,
+            lower_limit=cell_statistics_widget.colourmap_lower_limit,
+            upper_limit=cell_statistics_widget.colourmap_upper_limit,
+            autolimits=cell_statistics_widget.colourmap_autolimits.value,
+        )
     )
 
     return cell_statistics_widget
@@ -359,15 +374,108 @@ def _create_cell_statistics_widgets() -> list[Widget]:
     return [image, labels, run, export]
 
 
+def _create_colour_labels_widgets() -> list[Widget]:
+    """Create widgets for colouring Labels layers by their featuers"""
+
+    create_colour_labels_heading = magicgui.widgets.create_widget(
+        label="<b>Colour by statistic</b>",  # bold label
+        widget_type="Label",
+        gui_only=True,
+    )
+
+    labels_tooltip = "Select a 'Labels' layer to set colourmap for"
+    labels = magicgui.widgets.create_widget(
+        annotation=napari.layers.Labels,
+        name="colourmap_input_labels",
+        label="labels",
+        options={"tooltip": labels_tooltip},
+    )
+
+    statisitc_tooltip = "Select which statistic to use for colouring the 'Labels'"
+    statistic = magicgui.widgets.create_widget(
+        name="colourmap_statistic",
+        value="None",
+        label="statistic",
+        widget_type="ComboBox",
+        options={
+            "choices": ["None", "area", "perimeter", "orientation", "neighbours"],
+            "tooltip": statisitc_tooltip,
+        },
+    )
+
+    lower_limit_tooltip = "Set the lower limit for the colourmap"
+    lower_limit = magicgui.widgets.create_widget(
+        value=0.0,
+        name="colourmap_lower_limit",
+        label="lower limit",
+        widget_type="FloatSpinBox",
+        options={
+            "tooltip": lower_limit_tooltip,
+            "min": -3.4 * 10**38,
+            "max": 3.4 * 10**38,
+        },
+    )
+
+    upper_limit_tooltip = "Set the upper limit for the colourmap"
+    upper_limit = magicgui.widgets.create_widget(
+        value=100.0,
+        name="colourmap_upper_limit",
+        label="upper limit",
+        widget_type="FloatSpinBox",
+        options={
+            "tooltip": upper_limit_tooltip,
+            "min": -3.4 * 10**38,
+            "max": 3.4 * 10**38,
+        },
+    )
+
+    auto_limits_tooltip = "Automatically set colourmap limits based on feature values."
+    auto_limits = magicgui.widgets.create_widget(
+        value=False,
+        name="colourmap_autolimits",
+        label="Auto-limits",
+        widget_type="CheckBox",
+        options={"tooltip": auto_limits_tooltip},
+    )
+
+    create_colourmap_tooltip = "Create colourmap for the selected Labels layer"
+    create_colourmap = magicgui.widgets.create_widget(
+        name="colourmap_create_button",
+        label="Create colourmap",
+        widget_type="PushButton",
+        options={"tooltip": create_colourmap_tooltip},
+    )
+
+    return [
+        create_colour_labels_heading,
+        labels,
+        statistic,
+        lower_limit,
+        upper_limit,
+        auto_limits,
+        create_colourmap,
+    ]
+
+
 def _update_cell_statistics(
     layers: list[napari.layers.Layer],
     frame: int,
 ) -> None:
-    """Update Labels cell_statistics for current frame"""
+    """Update Labels cell_statistics for current frame.
+
+    Apply any colourmaps for the Labels layers at the current frame.
+    """
 
     for layer in layers:
         try:
             layer.features = layer.metadata["cell_statistics"][frame]
+        except KeyError:
+            pass
+        except IndexError:
+            pass
+
+        try:
+            layer.color = layer.metadata["colourmaps"][frame]
         except KeyError:
             pass
         except IndexError:
@@ -399,7 +507,7 @@ def run_cell_statistics(
     try:
         labels.features = cell_statistics[current_frame]
     except IndexError:
-        pass
+        return
 
 
 def export_cell_statistics(
@@ -447,3 +555,82 @@ def _cell_statistics_to_csv(
     # confirm export
     message = f"'{labels.name}' cell statistics written to '{filename}'"
     napari.utils.notifications.show_info(message)
+
+
+def create_colourmaps(
+    labels: napari.layers.Labels,
+    colourmap_statistic: str,
+    lower_limit: Widget,
+    upper_limit: Widget,
+    *,
+    autolimits: bool,
+) -> None:
+    """Create a colourmap for a cell statistic each frame.
+
+    If the statistic is set to "None", then the colour mode is set to "auto", which will
+    colour regions based on their ids.
+
+    If the statistics is set to any other value, a colourmap is created for that
+    statistic for each frame.
+    """
+
+    if "cell_statistics" not in labels.metadata:
+        _msg = (
+            "Cannot create colourmaps - "
+            "the selected Labels layer has no cell staistics."
+        )
+        napari.utils.notifications.show_error(_msg)
+        return
+
+    if colourmap_statistic == "None":
+        labels.metadata.pop("metadata", None)
+        labels.color_mode = "auto"
+        return
+
+    cell_statistics = [
+        frame_statistics[colourmap_statistic]
+        for frame_statistics in labels.metadata["cell_statistics"]
+    ]
+    cell_indices = [
+        frame_statistics["index"]
+        for frame_statistics in labels.metadata["cell_statistics"]
+    ]
+
+    if autolimits:
+        lower_limit.value = min(min(statistics) for statistics in cell_statistics)
+        upper_limit.value = max(max(statistics) for statistics in cell_statistics)
+
+    colourmaps = [
+        _create_colourmap(
+            float(lower_limit.value),
+            float(upper_limit.value),
+            statistics,
+            indices,
+        )
+        for statistics, indices in zip(cell_statistics, cell_indices)
+    ]
+
+    labels.metadata["colourmaps"] = colourmaps
+
+    # Set cell colourmap for the current frame
+    viewer = napari.current_viewer()
+    current_frame = viewer.dims.current_step[0]
+    try:
+        labels.color = colourmaps[current_frame]
+    except IndexError:
+        return
+
+
+def _create_colourmap(
+    lower_limit: float,
+    upper_limit: float,
+    statistics: npt.NDArray,
+    indices: npt.NDArray,
+) -> dict[int, npt.NDArray]:
+    """Create a dictionary of colours - one per unique region"""
+
+    colourmap_data = (statistics - lower_limit) / upper_limit
+    colourmap_data = np.clip(colourmap_data, a_min=0, a_max=1)
+    colours = plt.cm.turbo(colourmap_data)
+
+    return {index: colour for index, colour in zip(indices, colours)}

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -491,9 +491,11 @@ def _update_cell_statistics(
         try:
             layer.color = layer.metadata["colourmaps"][frame]
         except KeyError:
-            pass
+            message = f"No colourmaps load apply to layer {layer.name}"
+            logger.log(level=1, msg=message)
         except IndexError:
-            pass
+            message = f"No colourmap to apply for layer {layer.name} at frame {frame}"
+            logger.log(level=9, msg=message)
 
 
 def run_cell_statistics(
@@ -631,13 +633,18 @@ def create_colourmaps(
 
     labels.metadata["colourmaps"] = colourmaps
 
+    # confirm colourmaps created
+    message = f"'{colourmap_statistic}' colourmaps created for '{labels.name}'"
+    napari.utils.notifications.show_info(message)
+
     # Set cell colourmap for the current frame
     viewer = napari.current_viewer()
     current_frame = viewer.dims.current_step[0]
     try:
         labels.color = colourmaps[current_frame]
     except IndexError:
-        return
+        message = f"No colourmap to apply for {labels.name} at frame {current_frame}"
+        logger.debug(message)
 
 
 def _create_colourmap(

--- a/src/napari_epitools/_widget.py
+++ b/src/napari_epitools/_widget.py
@@ -659,4 +659,4 @@ def _create_colourmap(
     colourmap_data = np.clip(colourmap_data, a_min=0, a_max=1)
     colours = plt.cm.turbo(colourmap_data)
 
-    return {index: colour for index, colour in zip(indices, colours)}
+    return dict(zip(indices, colours))

--- a/src/napari_epitools/analysis/cell_statistics.py
+++ b/src/napari_epitools/analysis/cell_statistics.py
@@ -21,7 +21,7 @@ import skimage.measure
 def calculate_cell_statistics(
     image: napari.types.ImageData,
     labels: napari.types.LabelsData,
-) -> tuple[list[dict[str, npt.NDArray]], list[skimage.graph._rag.RAG]]:
+) -> tuple[list[dict[str, npt.NDArray]], list[skimage.graph.RAG]]:
     """Calculate the region based properties of a segmented image"""
 
     # Calculate cell statistics for each frame
@@ -66,7 +66,7 @@ def _calculate_cell_statistics(
 
 def _create_graphs(
     labels: napari.types.LabelsData,
-) -> skimage.graph._rag.RAG:
+) -> list[skimage.graph.RAG]:
     """Create graph of neighbouring cells"""
 
     graphs = [skimage.graph.RAG(frame_labels) for frame_labels in labels]


### PR DESCRIPTION
Fixes #51 


https://user-images.githubusercontent.com/29753790/230074652-1bf638b0-7e98-47fa-8288-bbf9f8479aef.mp4


- set minimum version of `scikit-image>=0.20`, as part of the API that we're using change in this version (`skimage.future.RAG` was renamed to `skimage.graph.RAG`). Also remove unused dependencies

- add widgets for creating colourmaps based on cell statistics

- to create a colourmap: select a `Labels` layer to create the colourmaps for, set the range to use for creating the colourmaps, then click 'Create colourmaps'

- this will create a series of colourmaps for the selected statistic - one per frame - and store them as a list in `Labels.metadata["colourmaps"]`

- when scrolling through frames, the colourmap is updated for the current frame

- current options for colouring by statistic:
    - id - in which case the `Labels.color_mode` is set to `auto`, which will colour the cells by id
    - area
    - perimeter
    - orientation
    - number of neighbours

- there is an `Auto-limits` option for setting the range for the colourmaps. If selected, the minimum and maximum values of the selected statistic (across all frames) will be used for setting the range. When creating the colourmap, the 'lower limit' and 'upper limit' widgets will be updated with the automatically calculated values so the user know what values have been used

- there are some issues / discussion with colouring a `Labels` layer by features in `napari` that we might to want keep track of:
    - https://github.com/napari/napari/issues/4384
    - https://github.com/napari/napari/issues/5129
    - https://napari.zulipchat.com/#narrow/stream/212875-general/topic/labels.20.28direct.29
    - https://forum.image.sc/t/exloring-image-segment-features-in-napari/75222/3

- there are some other plugins that create colourmaps based on cell statistics, but I couldn't find any that allow setting the colourmap range. Plus, they tend to do the `regionprops` calculation on-the-fly when the frame is changed rather than storing results for all frames in the metadata, which means there is usually a lag when scrolling through frames while the data is processed and colourmaps created

