### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ https://napari.org/plugins/index.html
 
 ## Installation
 
-You can install `napari-epitools` via [pip]:
+`napari-epitools` is not yet available to install from PyPI or napari-hub.
 
-    pip install napari-epitools
+To install, please clone the repository and do a local install using `pip`:
+
+```
+git clone git@github.com:epitools/epitools.git
+cd epitools
+python -m pip install .
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://napari.org/plugins/index.html
 To install, please clone the repository and do a local install using `pip`:
 
 ```
-git clone git@github.com:epitools/epitools.git
+git clone https://github.com/epitools/epitools.git
 cd epitools
 python -m pip install .
 ```


### PR DESCRIPTION
Changes the installation instructions:
- previously mentioned installing using `pip` but we haven't released it on PyPI yet
- now says to clone the repository and do a local install using `pip`