### PR TITLE
Read pixel spacing from tif files and use when calculating regionprops

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "magicgui",
     "qtpy",
     "scikit-image>=0.20",
+    "PartSeg",
 ]
 description = "EpiTools Plugin"
 dynamic = [

--- a/src/napari_epitools/analysis/projection.py
+++ b/src/napari_epitools/analysis/projection.py
@@ -127,6 +127,7 @@ def calculate_projection(
         max_indices = smoothed_t.argmax(axis=0)
 
         confidencemap = z_size * max_intensity / np.sum(smoothed_t, axis=0)
+        np.nan_to_num(confidencemap, copy=False)
         confthres = np.median(confidencemap[confidencemap > np.median(confidencemap)])
 
         # keep only the brightest surface points (intensity in 1 quartile)

--- a/src/napari_epitools/main.py
+++ b/src/napari_epitools/main.py
@@ -24,6 +24,10 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+THREE_DIMENSIONAL = 3  # ZYX
+FOUR_DIMENSIONAL = 4  # TZYX
+
+
 def create_projection_widget() -> magicgui.widgets.Container:
     """Create a widget to project a 4d timeseries (TZYX) along the z dimension"""
 
@@ -60,10 +64,33 @@ def run_projection(
         cutoff_distance,
     )
 
+    # Remove z dimension from scale and translate arrays
+    if image.ndim == THREE_DIMENSIONAL:  # ZYX
+        mask = [1, 2]
+    elif image.ndim == FOUR_DIMENSIONAL:  # TZYX
+        mask = [0, 2, 3]
+
+    two_d_scale = image.metadata["scale"][mask]
+    two_d_translate = np.asarray(image.translate)[mask]
+
+    # spacing for regionprops
+    two_d_spacing = (
+        image.metadata["spacing"]
+        if image.ndim == THREE_DIMENSIONAL
+        else image.metadata["spacing"][1:]
+    )
+
+    two_d_metadata = {
+        "scale": two_d_scale,
+        "spacing": two_d_spacing,
+    }
+
     viewer = napari.current_viewer()
     viewer.add_image(
         data=projected_data,
         name="Projection",
+        translate=two_d_translate,
+        metadata=two_d_metadata,
     )
 
 
@@ -128,9 +155,16 @@ def run_segmentation(
         threshold=threshold,
     )
 
+    labels_metadata = {
+        "scale": image.metadata["scale"],
+        "spacing": image.metadata["spacing"],
+    }
+
     viewer = napari.current_viewer()
     viewer.add_labels(
         data=labels_data,
+        translate=image.translate,
+        metadata=labels_metadata,
         name="Cells",
     )
     viewer.add_points(
@@ -225,6 +259,7 @@ def run_cell_statistics(
     cell_statistics, graphs = napari_epitools.analysis.calculate_cell_statistics(
         image=image.data,
         labels=labels.data,
+        pixel_spacing=image.metadata["spacing"],
     )
 
     # We will use these to update the cell stats at each frame

--- a/src/napari_epitools/napari.yaml
+++ b/src/napari_epitools/napari.yaml
@@ -4,7 +4,7 @@ contributions:
   commands:
     - id: napari-epitools.get_reader
       python_name: napari_epitools._reader:napari_get_reader
-      title: Open data with napari EpiTools
+      title: EpiTools (".tif", ".tiff")
     - id: napari-epitools.write_multiple
       python_name: napari_epitools._writer:write_multiple
       title: Save multi-layer data with napari EpiTools
@@ -26,7 +26,7 @@ contributions:
   readers:
     - command: napari-epitools.get_reader
       accepts_directories: false
-      filename_patterns: ["*.npy"]
+      filename_patterns: ["*.tif", "*.tiff"]
   writers:
     - command: napari-epitools.write_multiple
       layer_types: ["image*", "labels*"]

--- a/src/napari_epitools/napari.yaml
+++ b/src/napari_epitools/napari.yaml
@@ -4,7 +4,7 @@ contributions:
   commands:
     - id: napari-epitools.get_reader
       python_name: napari_epitools._reader:napari_get_reader
-      title: EpiTools (".tif", ".tiff")
+      title: Open data with napari EpiTools
     - id: napari-epitools.write_multiple
       python_name: napari_epitools._writer:write_multiple
       title: Save multi-layer data with napari EpiTools


### PR DESCRIPTION
Fixes #52 

- add `PartSeg` as a dependency - it reads several file formats along with some useful metadata

- PartSeg comes with napari readers for various file formats. However, it [scales the image](https://napari.org/stable/api/napari.layers.Image.html#:~:text=\)%20%E2%80%93%20Layer%20metadata.-,scale,-\(tuple%20of) in the viewer based on the pixel spacing. This would be fine, but after projecting the 3d image to 2d it is very difficult to fine to correct plane that the 2d image is in (because the pixel spacing in `z` much larger than the spacing in `xy`). So I've updated the EpiTools reader to be a wrapper around one of the PartSeg readers that removes the scaling from 

- use the pixel spacing when calculating cell statistics with regionprops. Area and perimeter are then converted to be in  $\micro\text{m}^2$ and $\micro\text{m}^2$, respectively

