### PR TITLE
Fix pixel spacing used when calculating cell stats

### DIFF
--- a/src/epitools/main.py
+++ b/src/epitools/main.py
@@ -242,7 +242,7 @@ def run_cell_statistics(
 
     pixel_spacing = (
         image.metadata["yx_spacing"]
-        if "spacing" in image.metadata
+        if "yx_spacing" in image.metadata
         else DEFAULT_PIXEL_SPACING
     )
 


### PR DESCRIPTION
The default pixel spacing is currently always being used when calculating cell stats, whereas it should only be used if an image doesn't have the pixel spacing info.

This fixes the check for whether an image has the pixel spacing info