### PR TITLE
Add neighbour ids to cell statistics

### DIFF
--- a/src/epitools/analysis/cell_statistics.py
+++ b/src/epitools/analysis/cell_statistics.py
@@ -191,7 +191,7 @@ def _calculate_graph_statistics(
     cell_statistics: list[dict[str, npt.NDArray]],
     graphs: skimage.graph._rag.RAG,
 ) -> None:
-    """Calcualte additional cell statistics from graphs.
+    """Calculate additional cell statistics from graphs.
 
     Adds results directly to 'cell_statistics' dictionaries.
     """
@@ -200,4 +200,9 @@ def _calculate_graph_statistics(
         indices = stats["index"]
 
         num_neighbours = np.asarray([len(graph[index]) for index in indices])
-        cell_statistics[frame]["neighbours"] = num_neighbours
+        cell_statistics[frame]["num_neighbours"] = num_neighbours
+
+        id_neighbours = [list(graph.neighbors(index)) for index in indices]
+        cell_statistics[frame]["id_neighbours"] = id_neighbours
+
+


### PR DESCRIPTION
Hi all! I have made this tiny modification to add the neighbour ids to the cell statistics csv output. I have tested it locally with the sample data the following way:

1. I created a dedicated environment
```
conda create -n epitools-testing python=3.10 -y
conda activate epitools-testing
```
2. Then inside the repo folder:
```
python -m pip install napari[all]
python -m pip install -e .
python -m pip install -e .[wf]
napari
```
3. From inside napari I loaded sample data, projected, segmented and then called calculate statistics. Then exported the `.csv` which now contains the neighbour ids as last column (see below):

<img width="232" alt="Screenshot 2023-05-22 at 16 28 00" src="https://github.com/epitools/epitools/assets/33309117/a67130f4-addb-44e9-ac71-6b1bf362bcb4">

Let me know if this is fine or if a different output format would work better.
