### PR TITLE
Add new widget for 2ch proj

### DIFF
--- a/src/epitools/_reader.py
+++ b/src/epitools/_reader.py
@@ -15,7 +15,8 @@ import PartSegCore.analysis.load_functions
 import PartSegCore.napari_plugins.loader
 
 if TYPE_CHECKING:
-    from typing import Any, Callable
+    from collections.abc import Callable
+    from typing import Any
 
     import numpy.typing as npt
 

--- a/src/epitools/analysis/projection.py
+++ b/src/epitools/analysis/projection.py
@@ -197,7 +197,7 @@ def calculate_projection(
 
         t_interp[t] = _calculate_projected_image(input_image[t], z_interp)
 
-    if input_image_2 is None:
+    if input_image_2 is None or t_interp_2 is None:
         t_interp_2 = None
     else:
         # second channel projected based on the first one (reference channel)

--- a/src/epitools/analysis/projection.py
+++ b/src/epitools/analysis/projection.py
@@ -100,8 +100,7 @@ def _calculate_projected_image(
 def calculate_projection(
     input_image: npt.NDArray[np.float64],
     smoothing_radius: float,
-    surface_smoothness_1: int,
-    surface_smoothness_2: int,
+    surface_smoothness: list[int],
     cut_off_distance: int,
     input_image_2: Union[npt.NDArray[np.float64], None] = None,
 ) -> tuple[npt.NDArray[np.float64], Union[npt.NDArray[np.float64], None]]:
@@ -123,13 +122,9 @@ def calculate_projection(
         smoothing_radius:
             Kernel radius for gaussian blur to apply before estimating the surface.
 
-        surface_smoothness_1:
-            Surface smoothness for 1st griddata estimation. Larger values will produce
-            greater smoothing.
-
-        surface_smoothness_2:
-            Surface smoothness for 2nd iteration of smoothing. Again, larger values
-            will produce greater smoothing.
+        surface_smoothness:
+            Surface smoothness for 1st and 2nd griddata estimation.
+            Larger values will produce greater smoothing.
 
         cut_off_distance:
             Cutoff distance in z-planes from the first estimated surface.
@@ -175,7 +170,7 @@ def calculate_projection(
         mask = confidencemap > confthres
         max_indices_confthres = max_indices * mask
         z_interp = _interpolate(
-            max_indices_confthres, x_size, y_size, surface_smoothness_1
+            max_indices_confthres, x_size, y_size, surface_smoothness[0]
         )
 
         # given the height locations of the surface (z_interp) compute the difference
@@ -193,7 +188,7 @@ def calculate_projection(
         # (max_indices_cut) this is to make sure that the highest intensity points will
         # be selected from the correct surface (The coarse grained estimate could
         # potentially approximate the origin of the point to another plane)
-        z_interp = _interpolate(max_indices_cut, x_size, y_size, surface_smoothness_2)
+        z_interp = _interpolate(max_indices_cut, x_size, y_size, surface_smoothness[1])
 
         t_interp[t] = _calculate_projected_image(input_image[t], z_interp)
 

--- a/src/epitools/analysis/projection.py
+++ b/src/epitools/analysis/projection.py
@@ -6,6 +6,7 @@ along the z-dimension.
 """
 
 import itertools
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -102,8 +103,8 @@ def calculate_projection(
     surface_smoothness_1: int,
     surface_smoothness_2: int,
     cut_off_distance: int,
-    input_image_2: npt.NDArray[np.float64] | None = None,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64] | None]:
+    input_image_2: Union[npt.NDArray[np.float64], None] = None,
+) -> tuple[npt.NDArray[np.float64], Union[npt.NDArray[np.float64], None]]:
     """Z projection using image interpolation.
 
      Perform an iterative projection of 3D points along the z axis.
@@ -156,7 +157,9 @@ def calculate_projection(
 
     # We will always have a single slice in the Z dimension
     t_interp = np.zeros((t_size, SINGLE_SLICE, y_size, x_size))
-    t_interp_2: npt.NDArray | None = np.zeros((t_size, SINGLE_SLICE, y_size, x_size))
+    t_interp_2: Union[npt.NDArray, None] = np.zeros(
+        (t_size, SINGLE_SLICE, y_size, x_size)
+    )
 
     for t in range(t_size):
         smoothed_t = smoothed_imstack[t]

--- a/src/epitools/main.py
+++ b/src/epitools/main.py
@@ -41,8 +41,10 @@ def create_projection_widget() -> magicgui.widgets.Container:
         lambda: run_projection(
             image=projection_widget.input_image.value,
             smoothing_radius=projection_widget.smoothing_radius.value,
-            surface_smoothness_1=projection_widget.surface_smoothness_1.value,
-            surface_smoothness_2=projection_widget.surface_smoothness_2.value,
+            surface_smoothness=[
+                projection_widget.surface_smoothness_1.value,
+                projection_widget.surface_smoothness_2.value,
+            ],
             cutoff_distance=projection_widget.cutoff_distance.value,
         ),
     )
@@ -61,8 +63,10 @@ def create_projection_2ch_widget() -> magicgui.widgets.Container:
         lambda: run_projection(
             image=projection_2ch_widget.refchannel.value,
             smoothing_radius=projection_2ch_widget.smoothing_radius.value,
-            surface_smoothness_1=projection_2ch_widget.surface_smoothness_1.value,
-            surface_smoothness_2=projection_2ch_widget.surface_smoothness_2.value,
+            surface_smoothness=[
+                projection_2ch_widget.surface_smoothness_1.value,
+                projection_2ch_widget.surface_smoothness_2.value,
+            ],
             cutoff_distance=projection_2ch_widget.cutoff_distance.value,
             second_image=projection_2ch_widget.channel.value,
         ),
@@ -74,8 +78,7 @@ def create_projection_2ch_widget() -> magicgui.widgets.Container:
 def run_projection(
     image: napari.layers.Image,
     smoothing_radius,
-    surface_smoothness_1,
-    surface_smoothness_2,
+    surface_smoothness,
     cutoff_distance,
     second_image: napari.layers.Image | None = None,
 ) -> None:
@@ -86,8 +89,7 @@ def run_projection(
         projected_data_1, projected_data_2 = epitools.analysis.calculate_projection(
             image.data,
             smoothing_radius,
-            surface_smoothness_1,
-            surface_smoothness_2,
+            surface_smoothness,
             cutoff_distance,
             second_image.data,
         )
@@ -117,8 +119,7 @@ def run_projection(
         projected_data, _ = epitools.analysis.calculate_projection(
             image.data,
             smoothing_radius,
-            surface_smoothness_1,
-            surface_smoothness_2,
+            surface_smoothness,
             cutoff_distance,
         )
 

--- a/src/epitools/main.py
+++ b/src/epitools/main.py
@@ -19,6 +19,7 @@ import epitools.widgets
 __all__ = [
     "create_projection_widget",
     "create_segmentation_widget",
+    "create_projection_2ch_widget",
     "create_cell_statistics_widget",
 ]
 
@@ -49,33 +50,88 @@ def create_projection_widget() -> magicgui.widgets.Container:
     return projection_widget
 
 
+def create_projection_2ch_widget() -> magicgui.widgets.Container:
+    """Create a widget to project a 2 channel, 4d timeseries (TZYX)
+    along the z dimension based on a reference channel"""
+
+    projection_2ch_widget = epitools.widgets.create_projection_2ch_widget()
+
+    # Project the timeseries when pressing the 'Run' button
+    projection_2ch_widget.run.changed.connect(
+        lambda: run_projection(
+            image=projection_2ch_widget.refchannel.value,
+            smoothing_radius=projection_2ch_widget.smoothing_radius.value,
+            surface_smoothness_1=projection_2ch_widget.surface_smoothness_1.value,
+            surface_smoothness_2=projection_2ch_widget.surface_smoothness_2.value,
+            cutoff_distance=projection_2ch_widget.cutoff_distance.value,
+            second_image=projection_2ch_widget.channel.value,
+        ),
+    )
+
+    return projection_2ch_widget
+
+
 def run_projection(
     image: napari.layers.Image,
     smoothing_radius,
     surface_smoothness_1,
     surface_smoothness_2,
     cutoff_distance,
+    second_image: napari.layers.Image | None = None,
 ) -> None:
     """Project a 4d timeseries along the z dimension"""
 
-    projected_data = epitools.analysis.calculate_projection(
-        image.data,
-        smoothing_radius,
-        surface_smoothness_1,
-        surface_smoothness_2,
-        cutoff_distance,
-    )
+    "If second_image is not empty, project 2 channels based on reference channel"
+    if second_image is not None:
+        projected_data_1, projected_data_2 = epitools.analysis.calculate_projection(
+            image.data,
+            smoothing_radius,
+            surface_smoothness_1,
+            surface_smoothness_2,
+            cutoff_distance,
+            second_image.data,
+        )
 
-    viewer = napari.current_viewer()
-    viewer.add_image(
-        data=projected_data,
-        name="Projection",
-        scale=image.scale,
-        translate=image.translate,
-        rotate=image.rotate,
-        plane=image.plane,
-        metadata=image.metadata,
-    )
+        viewer = napari.current_viewer()
+        viewer.add_image(
+            data=projected_data_1,
+            name="Projection_ch1",
+            scale=image.scale,
+            translate=image.translate,
+            rotate=image.rotate,
+            plane=image.plane,
+            metadata=image.metadata,
+        )
+
+        viewer.add_image(
+            data=projected_data_2,
+            name="Projection_ch2",
+            scale=image.scale,
+            translate=image.translate,
+            rotate=image.rotate,
+            plane=image.plane,
+            metadata=image.metadata,
+        )
+
+    else:
+        projected_data, _ = epitools.analysis.calculate_projection(
+            image.data,
+            smoothing_radius,
+            surface_smoothness_1,
+            surface_smoothness_2,
+            cutoff_distance,
+        )
+
+        viewer = napari.current_viewer()
+        viewer.add_image(
+            data=projected_data,
+            name="Projection",
+            scale=image.scale,
+            translate=image.translate,
+            rotate=image.rotate,
+            plane=image.plane,
+            metadata=image.metadata,
+        )
 
 
 def create_segmentation_widget() -> magicgui.widgets.Container:

--- a/src/epitools/napari.yaml
+++ b/src/epitools/napari.yaml
@@ -17,6 +17,9 @@ contributions:
     - id: epitools.projection_widget
       python_name: epitools.main:create_projection_widget
       title: Epitools Projection Widget
+    - id: epitools.projection_2ch_widget
+      python_name: epitools.main:create_projection_2ch_widget
+      title: Epitools Projection Widget 2 Channels
     - id: epitools.segmentation_widget
       python_name: epitools.main:create_segmentation_widget
       title: Epitools Segmentation Widget
@@ -42,6 +45,8 @@ contributions:
     - command: epitools.projection_widget
       # autogenerate: true <- for use with assistant
       display_name: Projection (selective plane)
+    - command: epitools.projection_2ch_widget
+      display_name: Projection (2 channel with reference channel)
     - command: epitools.segmentation_widget
       display_name: Segmentation (local minima seeded watershed)
     - command: epitools.cell_statistics_widget

--- a/src/epitools/widgets/__init__.py
+++ b/src/epitools/widgets/__init__.py
@@ -1,11 +1,13 @@
 from epitools.widgets import dialogue
 from epitools.widgets.cell_statistics import create_cell_statistics_widget
 from epitools.widgets.projection import create_projection_widget
+from epitools.widgets.projection_2ch import create_projection_2ch_widget
 from epitools.widgets.segmentation import create_segmentation_widget
 
 __all__ = [
     "dialogue",
     "create_cell_statistics_widget",
     "create_projection_widget",
+    "create_projection_2ch_widget",
     "create_segmentation_widget",
 ]

--- a/src/epitools/widgets/projection_2ch.py
+++ b/src/epitools/widgets/projection_2ch.py
@@ -7,7 +7,8 @@ __all__ = [
 
 
 def create_projection_2ch_widget() -> magicgui.widgets.Container:
-    """Create a widget for projecting a 2 channel, 3d timeseries to a 2d timeseries based on a reference channel"""
+    """Create a widget for projecting a 2 channel, 3d timeseries to a
+    2d timeseries based on a reference channel"""
 
     refchannel_tooltip = (
         "Select a 'Reference' channel to project along the z-dimension."
@@ -19,7 +20,8 @@ def create_projection_2ch_widget() -> magicgui.widgets.Container:
         options={"tooltip": refchannel_tooltip},
     )
 
-    channel_tooltip = "Select a second channel to project along the z-dimension based on the 'Reference'."
+    channel_tooltip = "Select a second channel to project along the \
+    z-dimension based on the 'Reference'."
     channel = magicgui.widgets.create_widget(
         annotation=napari.layers.Image,
         name="channel",

--- a/src/epitools/widgets/projection_2ch.py
+++ b/src/epitools/widgets/projection_2ch.py
@@ -1,0 +1,99 @@
+import magicgui.widgets
+import napari
+
+__all__ = [
+    "create_projection_2ch_widget",
+]
+
+
+def create_projection_2ch_widget() -> magicgui.widgets.Container:
+    """Create a widget for projecting a 2 channel, 3d timeseries to a 2d timeseries based on a reference channel"""
+
+    refchannel_tooltip = "Select a 'Reference' channel to project along the z-dimension."
+    refchannel = magicgui.widgets.create_widget(
+        annotation=napari.layers.Image,
+        name="refchannel",
+        label="reference channel",
+        options={"tooltip": refchannel_tooltip},
+    )
+
+    channel_tooltip = "Select a second channel to project along the z-dimension based on the 'Reference'."
+    channel = magicgui.widgets.create_widget(
+        annotation=napari.layers.Image,
+        name="channel",
+        label="second channel",
+        options={"tooltip": channel_tooltip},
+    )
+
+    smoothing_radius_tooltip = (
+        "Kernel radius for gaussian blur to apply before estimating the surface."
+    )
+    smoothing_radius = magicgui.widgets.create_widget(
+        value=1,
+        name="smoothing_radius",
+        label="smoothing radius",
+        widget_type="FloatSpinBox",
+        options={
+            "tooltip": smoothing_radius_tooltip,
+        },
+    )
+
+    surface_smoothness_1_tooltip = (
+        "Surface smoothness for 1st griddata estimation, larger means smoother."
+    )
+    surface_smoothness_1 = magicgui.widgets.create_widget(
+        value=5,
+        name="surface_smoothness_1",
+        label="surface smoothness 1",
+        widget_type="SpinBox",
+        options={
+            "tooltip": surface_smoothness_1_tooltip,
+        },
+    )
+
+    surface_smoothness_2_tooltip = (
+        "Surface smoothness for 2nd griddata estimation, larger means smoother."
+    )
+    surface_smoothness_2 = magicgui.widgets.create_widget(
+        value=5,
+        name="surface_smoothness_2",
+        label="surface smoothness 2",
+        widget_type="SpinBox",
+        options={
+            "tooltip": surface_smoothness_2_tooltip,
+        },
+    )
+
+    cutoff_distance_tooltip = (
+        "Cutoff distance in z-planes from the 1st estimated surface."
+    )
+    cutoff_distance = magicgui.widgets.create_widget(
+        value=3,
+        name="cutoff_distance",
+        label="z cutoff distance",
+        widget_type="SpinBox",
+        options={
+            "tooltip": cutoff_distance_tooltip,
+        },
+    )
+
+    run_button_tooltip = "Perform the projection"
+    run_button = magicgui.widgets.create_widget(
+        name="run",
+        label="Run",
+        widget_type="PushButton",
+        options={"tooltip": run_button_tooltip},
+    )
+
+    return magicgui.widgets.Container(
+        widgets=[
+            refchannel,
+            channel,
+            smoothing_radius,
+            surface_smoothness_1,
+            surface_smoothness_2,
+            cutoff_distance,
+            run_button,
+        ],
+        scrollable=False,
+    )

--- a/src/epitools/widgets/projection_2ch.py
+++ b/src/epitools/widgets/projection_2ch.py
@@ -9,7 +9,9 @@ __all__ = [
 def create_projection_2ch_widget() -> magicgui.widgets.Container:
     """Create a widget for projecting a 2 channel, 3d timeseries to a 2d timeseries based on a reference channel"""
 
-    refchannel_tooltip = "Select a 'Reference' channel to project along the z-dimension."
+    refchannel_tooltip = (
+        "Select a 'Reference' channel to project along the z-dimension."
+    )
     refchannel = magicgui.widgets.create_widget(
         annotation=napari.layers.Image,
         name="refchannel",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/tests/test_cell_statistics.py
+++ b/tests/test_cell_statistics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
 
 def test_add_cell_statistics_widget(

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import patch
 
 import napari

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -8,8 +8,7 @@ import napari
 from epitools.analysis import calculate_projection
 
 SMOOTHING_RADIUS = 0.2
-SURFACE_SMOOTHNESS_1 = 50
-SURFACE_SMOOTHNESS_2 = 50
+SURFACE_SMOOTHNESS = [50, 50]
 CUT_OFF_DISTANCE = 20
 PROJECTION_NDIM = 4
 
@@ -64,8 +63,7 @@ def test_calculate_projection(
     projection, _ = calculate_projection(
         image.data,
         SMOOTHING_RADIUS,
-        SURFACE_SMOOTHNESS_1,
-        SURFACE_SMOOTHNESS_2,
+        SURFACE_SMOOTHNESS,
         CUT_OFF_DISTANCE,
     )
 

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -61,7 +61,7 @@ def test_projection_widget_run_button(
 def test_calculate_projection(
     image: napari.layers.Image,
 ):
-    projection = calculate_projection(
+    projection, _ = calculate_projection(
         image.data,
         SMOOTHING_RADIUS,
         SURFACE_SMOOTHNESS_1,

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import patch
 
 import numpy as np


### PR DESCRIPTION
This PR addresses issue #116 and adds a new widget (Projection - 2 channel projection with reference channel) to perform projection of 2-channel images where one channel is the reference for the surface of interest. This will typically be a "clean" surface marker eg Decad for the apical surface and the second channel will be projected based on that. 

The new widget works as expected however I will need a bit of help in addressing some pre-commit checks.

Closes #116  